### PR TITLE
Droplet fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include cortix/examples/input/*
+include cortix/tests/input/*

--- a/cortix/examples/input/cortix-config-droplet.xml
+++ b/cortix/examples/input/cortix-config-droplet.xml
@@ -95,7 +95,7 @@
 
    <module_library name='droplet'>
     <parent_dir>
-    /home/dealmeida/mac-dealmeida/gentoo-home/work/codes/reprocessing/cortix-dev/cortix/cortix/examples/modulib/
+        $CORTIX/cortix/examples/modulib
     </parent_dir>
    </module_library>
 
@@ -112,10 +112,10 @@
 
    <module name="droplet" type="native">
     <library name='cortix.examples.modulib'>
-     <parent_dir>/home/dealmeida/mac-dealmeida/gentoo-home/work/codes/reprocessing/cortix-dev/cortix/</parent_dir>
+        <parent_dir>$CORTIX</parent_dir>
     </library>
     <input_file_name>droplet.input</input_file_name>
-    <input_file_path>/home/dealmeida/mac-dealmeida/gentoo-home/work/codes/reprocessing/cortix-dev/input/</input_file_path>
+    <input_file_path>$CORTIX/cortix/examples/input</input_file_path>
     <logger level="DEBUG">
      <file_handler level="DEBUG"> </file_handler>
      <console_handler level="INFO"> </console_handler>
@@ -132,11 +132,11 @@
    <module name="modulib.pyplot" type="native">
     <library name='cortix'>
      <parent_dir>
-      /home/dealmeida/mac-dealmeida/gentoo-home/work/codes/reprocessing/cortix-dev/cortix/
+         $CORTIX 
      </parent_dir>
     </library>
     <input_file_name>pyplot.input</input_file_name>
-    <input_file_path>/home/dealmeida/mac-dealmeida/gentoo-home/work/codes/reprocessing/cortix-dev/input/</input_file_path>
+    <input_file_path>$CORTIX/cortix/examples/input</input_file_path>
     <logger level="DEBUG">
      <file_handler level="DEBUG"> </file_handler>
      <console_handler level="INFO"> </console_handler>

--- a/cortix/examples/main/main_droplet.py
+++ b/cortix/examples/main/main_droplet.py
@@ -1,46 +1,30 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # This file is part of the Cortix toolkit evironment
-# https://github.com/dpploy/...
+# https://github.com/dpploy/cortix
 #
 # All rights reserved, see COPYRIGHT for full restrictions.
-# https://github.com/dpploy/COPYRIGHT
+# https://github.com/dpploy/cortix/blob/master/COPYRIGHT.txt
 #
 # Licensed under the GNU General Public License v. 3, please see LICENSE file.
 # https://www.gnu.org/licenses/gpl-3.0.txt
-"""
-Cortix: a program for system-level modules coupling, execution, and analysis.
 
-Cortix is a library and it is used by means of a driver. This file is a simple example
-of a driver. Many Cortix objects can be ran simultaneously; a single object
-may be sufficient since many simulation/tasks can be ran via one object.
-
-As Cortix evolves additional complexity may be added to this driver and/or other
-driver examples can be created.
-"""
-#*********************************************************************************
 import os
-from cortix import Cortix 
-#*********************************************************************************
+from cortix import Cortix
 
-def main():
+def run():
+    '''
+    Run the droplet example
 
- pwd                   = os.path.dirname(__file__)
- full_path_config_file = os.path.join(pwd, 'input/cortix-config-droplet.xml')
+    To run this:
 
- # NB: if another instantiation of Cortix occurs, the cortix wrk directory specified
- #     in the cortix configuration file must be different, else the logging facility 
- #     will have log file collision.
+    >> import cortix.examples.main.main_droplet as droplet
+    >> droplet.run()
+    '''
+    pwd = os.path.dirname(__file__)
+    full_path_config_file = os.path.join(pwd, '../input/cortix-config-droplet.xml')
+    cortix1 = Cortix('cortix-droplet', full_path_config_file)
+    cortix1.run_simulations(task_name="droplet-fall")
 
- cortix1 = Cortix( 'cortix-droplet', full_path_config_file ) # see cortix-config-droplet.xml
-#
-# cortix1.run_simulations( task_name='solo-droplet-fall' )
- cortix1.run_simulations( task_name='droplet-fall' )
-# cortix1.run_simulations( task_name='solo-pyplot' )
-
-#---------------------- end def main():-------------------------------------------
-
-#*********************************************************************************
-# Usage: -> python cortix-main.py or ./cortix-main.py
 if __name__ == "__main__":
- main()
+    run()

--- a/cortix/examples/main/main_executor.py
+++ b/cortix/examples/main/main_executor.py
@@ -30,7 +30,7 @@ from cortix import Cortix
 def main():
 
  pwd                   = os.path.dirname(__file__)
- full_path_config_file = os.path.join(pwd, 'input/cortix-config.xml')
+ full_path_config_file = os.path.join(pwd, '../input/cortix-config.xml')
 
  # NB: if another instantiation of Cortix occurs, the cortix wrk directory specified
  #     in the cortix configuration file must be different, else the logging facility 

--- a/cortix/examples/main/main_mpi.py
+++ b/cortix/examples/main/main_mpi.py
@@ -28,7 +28,7 @@ from cortix import Cortix
 def main():
 
     pwd = os.path.dirname(__file__)
-    full_path_config_file = os.path.join(pwd, 'input/cortix-config.xml')
+    full_path_config_file = os.path.join(pwd, '../input/cortix-config.xml')
 
     # NB: if another instantiation of Cortix occurs, the cortix wrk directory specified
     #     in the cortix configuration file must be different, else the logging facility

--- a/cortix/examples/main/main_pthread.py
+++ b/cortix/examples/main/main_pthread.py
@@ -26,7 +26,7 @@ from cortix import Cortix
 def main():
 
  pwd                   = os.path.dirname(__file__)
- full_path_config_file = os.path.join(pwd, 'input/cortix-config.xml')
+ full_path_config_file = os.path.join(pwd, '../input/cortix-config.xml')
 
  # NB: if another instantiation of Cortix occurs, the cortix wrk directory specified
  #     in the cortix configuration file must be different, else the logging facility 

--- a/cortix/src/launcher.py
+++ b/cortix/src/launcher.py
@@ -43,9 +43,16 @@ class Launcher(Thread):
         assert cortix_comm_full_path_file_name[-1] is not '/' \
                '%r'%cortix_comm_full_path_file_name
 
+        cortix_path = os.path.abspath(os.path.join(__file__, "../../.."))
+
+
+        if "$CORTIX" in input_full_path_file_name:
+            self.__input_full_path_file_name = input_full_path_file_name.replace("$CORTIX", cortix_path)
+        else:
+            self.__input_full_path_file_name = input_full_path_file_name
+
         self.__module_name = module_name
         self.__slot_id = slot_id
-        self.__input_full_path_file_name = input_full_path_file_name
         self.__cortix_param_full_path_file_name = cortix_param_full_path_file_name
         self.__cortix_comm_full_path_file_name = cortix_comm_full_path_file_name
         self.__runtime_status_full_path = runtime_status_full_path

--- a/cortix/tests/input/cortix-config-droplet.xml
+++ b/cortix/tests/input/cortix-config-droplet.xml
@@ -95,7 +95,7 @@
 
    <module_library name='droplet'>
     <parent_dir>
-        ../examples/modulib
+        $CORTIX/cortix/examples/modulib
     </parent_dir>
    </module_library>
 
@@ -112,10 +112,10 @@
 
    <module name="droplet" type="native">
     <library name='cortix.examples.modulib'>
-        <parent_dir>../../</parent_dir>
+        <parent_dir>$CORTIX</parent_dir>
     </library>
     <input_file_name>droplet.input</input_file_name>
-    <input_file_path>input/</input_file_path>
+    <input_file_path>$CORTIX/cortix/examples/input</input_file_path>
     <logger level="DEBUG">
      <file_handler level="DEBUG"> </file_handler>
      <console_handler level="INFO"> </console_handler>
@@ -132,11 +132,11 @@
    <module name="modulib.pyplot" type="native">
     <library name='cortix'>
      <parent_dir>
-         ../../ 
+         $CORTIX 
      </parent_dir>
     </library>
-    <input_file_name>pyplot-test.input</input_file_name>
-    <input_file_path>input/</input_file_path>
+    <input_file_name>pyplot.input</input_file_name>
+    <input_file_path>$CORTIX/cortix/examples/input</input_file_path>
     <logger level="DEBUG">
      <file_handler level="DEBUG"> </file_handler>
      <console_handler level="INFO"> </console_handler>

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,21 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cortix",
-    version="0.0.2",
+    version="0.0.4",
     author="Valmor F. de Almeida",
     author_email="Valmor_deAlmeida@uml.edu",
     description=" Cortix is a Python library for system-level\
                   module coupling, execution, and analysis.",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    include_package_data=True,
     url="https://github.com/dpploy/cortix",
-    packages=['cortix', 'cortix.docs', 'cortix.examples',\
+    packages=['cortix', 'cortix.docs', 'cortix.examples',
+              'cortix.examples.modulib', 'cortix.examples.main',
+              'cortix.examples.input', 'cortix.examples.modulib.droplet',\
               'cortix.modulib.pyplot','cortix.src',\
-              'cortix.src.utils', 'cortix.support', 'cortix.tests'],
+              'cortix.src.utils', 'cortix.support', 'cortix.tests',
+              'cortix.tests.input'],
     keywords = ['simulation', 'math'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This fix allows the droplet example to be run from anywhere on your system. This is achieved by adding the variable "$CORITX" to the xml input files. When the launcher reads in an input file, it replaces the occurence of $CORTIX with the full path to cortix's parent directory. This makes it so that config files need not be modified from system to system.